### PR TITLE
Crane fix extender issues + corrected setpoints

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -67,7 +67,7 @@ public final class Constants {
     public static final double kExtenderMid = 0;
     public static final double kExtenderLow = 0;
     public static final double kExtenderShelf = 0;
-    public static final double kExtenderPickup = 9;
+    public static final double kExtenderPickup = 12;
     public static final double kExtenderStart = 18; // Starts retracted by 6 inches to get 18 inches of extension
     public static final double kExtenderCeiling = kExtenderStart + 6; // 24 inches of extension (6 inches from start)
     public static final double kExtensionCap = 17; // 17 inches
@@ -83,12 +83,12 @@ public final class Constants {
     public static final double kElbowHardDeck = 10;
     public static final double kElbowStation = 45;
     public static final double kElbowHigh = 145;
-    public static final double kElbowPause = 150;
-    public static final double kElbowMid = 160;
+    public static final double kElbowPause = 160;
+    public static final double kElbowMid = 167;
     /** This is for low reef, not ground/low pickup. */
     public static final double kElbowLow = 200;
     public static final double kElbowShelf = 247.5;
-    public static final double kElbowCeiling = 270;
+    public static final double kElbowCeiling = 290;
     
     // pull from the .bak
     // public static final double kGripperMaxspeedMPS = 4.8;

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -60,36 +60,29 @@ public final class Constants {
     public static final double kWristCeiling = 225;
     
     // Extender limits
-    // Extender specifics are measured from or end to end, or center of elbow on piece to edge of extender piece without Claw
-    public static final double kExtenderHardDeck = 2;
-    public static final double kExtenderStation = 17.5;
-    public static final double kExtenderHigh = 22.75;
-    public static final double kExtenderMid = 0.5;
-    public static final double kExtenderLow = 0.5;
-    public static final double kExtenderShelf = 0.5;
-    public static final double kExtenderPickup = 23.25;
-    public static final double kExtenderCeiling = 25; // Absolute max is 36, be safer 27 -> 25
+    // Extender setpoints are measured with 2 inch soft limit included
+    public static final double kExtenderHardDeck = 0;
+    public static final double kExtenderStation = 10;
+    public static final double kExtenderHigh = 21;
+    public static final double kExtenderMid = 0;
+    public static final double kExtenderLow = 0;
+    public static final double kExtenderShelf = 0;
+    public static final double kExtenderPickup = 9;
+    public static final double kExtenderStart = 18; // Starts retracted by 6 inches to get 18 inches of extension
+    public static final double kExtenderCeiling = kExtenderStart + 6; // 24 inches of extension (6 inches from start)
     public static final double kExtensionCap = 17; // 17 inches
-    public static final double kExtenderClawOffset = 13; // 13 inches from Claw to the end of extender
-    public static final double kPullyCircumferenceInches = 2.25 * Math.PI; // 2.25 inches diameter, check again just in case
+    public static final double kExtenderClawOffset = 14; // 14 inches from edge of Claw to the soft limit of the extender
+    public static final double kPullyCircumferenceInches = 2.25 * Math.PI; // 2.25 inches diameter
     // TODO: Verify that measurement from butt of extender to extention limit is 17 inches, if not add offset
-    /** Limit extension from hard deck to elbow pause, measured from butt of extender to 17 in. extention limit. */
-    public static final double kExtenderLimit1 = kExtenderCeiling - kExtensionCap;
-    /** Limit extension from elbow pause to scoring/coral pickup, measured from claw tip to 17 in. extention limit. */
-    public static final double kExtenderLimit2 = kExtensionCap - kExtenderClawOffset;
-    public static final double kExtenderStart = kExtenderCeiling - 2; // extender butt pokes out by how much?
-    
-    // public static final double kExtenderStation = 27.5;
-    // public static final double kExtenderHigh = 32.75;
-    // public static final double kExtenderMid = 10.5;
-    // public static final double kExtenderLow = 3.75;
-    // public static final double kExtenderShelf = 10.5;
-    // public static final double kExtenderPickup = 23.25;
+    /** Keep extender butt-side within extension cap. */
+    public static final double kExtenderLimit1 = kExtenderCeiling - kExtensionCap + 2; // 2 inches from soft limit offset
+    /** Keep extender claw-side within extension cap. */
+    public static final double kExtenderLimit2 = kExtensionCap - kExtenderClawOffset - 2; // 2 inches from soft limit offset
 
     // Elbow limits
     public static final double kElbowHardDeck = 10;
-    public static final double kElbowStation = 25;
-    public static final double kElbowHigh = 140;
+    public static final double kElbowStation = 45;
+    public static final double kElbowHigh = 145;
     public static final double kElbowPause = 150;
     public static final double kElbowMid = 160;
     /** This is for low reef, not ground/low pickup. */

--- a/src/main/java/frc/robot/commands/CraneTeleopCommand.java
+++ b/src/main/java/frc/robot/commands/CraneTeleopCommand.java
@@ -121,7 +121,7 @@ public class CraneTeleopCommand extends Command {
             //             // If elbow is at hard deck, then we slightly retract the extender for stability
             //             Robot.crane.setWristPosition(CraneConstants.kWristOrigin);
             //             Robot.crane.setElbowPosition(CraneConstants.kElbowHardDeck);
-            //             Robot.crane.setExtenderPosition(CraneConstants.kExtenderLimit1); // Keep slightly retracted to improve stability
+            //             Robot.crane.setExtenderPosition(CraneConstants.kExtenderStart);
             //         }
             //     }
             // }

--- a/src/main/java/frc/robot/commands/CraneTeleopCommand.java
+++ b/src/main/java/frc/robot/commands/CraneTeleopCommand.java
@@ -41,91 +41,91 @@ public class CraneTeleopCommand extends Command {
             Robot.crane.setElbowPosition(Robot.crane.elbowSetpoint + PlayerConfigs.fineControlElbow * 0.1);
             Robot.crane.setExtenderPosition(Robot.crane.extenderSetpoint + PlayerConfigs.fineControlExtender * 0.05);
         } else {
-            // if(Robot.crane.craneState == 1) { // station
-            //     // TODO: VERIFY station logic
-            //     if(downToElbowPosition(CraneConstants.kElbowPause, CraneConstants.kExtenderLimit2)) {
-            //         Robot.crane.setWristPosition(CraneConstants.kWristVertical);
-            //         if(downToElbowPosition(CraneConstants.kElbowStation, CraneConstants.kExtenderLimit1)
-            //            && upToElbowPosition(CraneConstants.kElbowStation, CraneConstants.kExtenderLimit1)) {
-            //             Robot.crane.setWristPosition(CraneConstants.kWristVertical);
-            //             Robot.crane.setElbowPosition(CraneConstants.kElbowStation);
-            //             Robot.crane.setExtenderPosition(CraneConstants.kExtenderStation);
-            //         }
-            //     }
-            // }
-            // if(Robot.crane.craneState == 2) { // low pickup
-            // // TODO: CHECK LIMITS: bumper, claw dimensions, have MARGIN OF ERROR
-            //     if(upToElbowPosition(CraneConstants.kElbowPause, CraneConstants.kExtenderLimit1)) {
-            //         Robot.crane.setWristPosition(CraneConstants.kWristOrigin);
-            //         if(upToElbowPosition(CraneConstants.kElbowCeiling, CraneConstants.kExtenderLimit2)) {
-            //             // If elbow is at ceiling, then we extend the extender to pick up the coral
-            //             Robot.crane.setWristPosition(CraneConstants.kWristOrigin); // may need to rotate 180 degrees
-            //             Robot.crane.setElbowPosition(CraneConstants.kElbowCeiling);
-            //             Robot.crane.setExtenderPosition(CraneConstants.kExtenderPickup);
-            //         }
-            //     }
-            // }
-            // if(Robot.crane.craneState == 3) { // shelf reef
-            //     // TODO: VERIFY shelf reef logic
-            //     if(upToElbowPosition(CraneConstants.kElbowPause, CraneConstants.kExtenderLimit1)) {
-            //         Robot.crane.setWristPosition(CraneConstants.kWristOrigin);
-            //         if(upToElbowPosition(CraneConstants.kElbowShelf, CraneConstants.kExtenderLimit2)
-            //            && downToElbowPosition(CraneConstants.kElbowShelf, CraneConstants.kExtenderLimit2)) {
-            //             Robot.crane.setWristPosition(CraneConstants.kWristOrigin); // may need to rotate 180 degrees
-            //             Robot.crane.setElbowPosition(CraneConstants.kElbowShelf);
-            //             Robot.crane.setExtenderPosition(CraneConstants.kExtenderShelf);
-            //         }
-            //     }
-            // }
-            // if(Robot.crane.craneState == 4) { // low reef
-            //     // TODO: VERIFY low reef logic
-            //     if(upToElbowPosition(CraneConstants.kElbowPause, CraneConstants.kExtenderLimit1)) {
-            //         Robot.crane.setWristPosition(CraneConstants.kWristVertical);
-            //         if(upToElbowPosition(CraneConstants.kElbowLow, CraneConstants.kExtenderLimit2)
-            //            && downToElbowPosition(CraneConstants.kElbowLow, CraneConstants.kExtenderLimit2)) {
-            //             Robot.crane.setWristPosition(CraneConstants.kWristVertical);
-            //             Robot.crane.setElbowPosition(CraneConstants.kElbowLow);
-            //             Robot.crane.setExtenderPosition(CraneConstants.kExtenderLow);
-            //         }
-            //     }
-            // }
-            // if(Robot.crane.craneState == 5) { // mid reef
-            //     // TODO: VERIFY mid reef logic
-            //     if(upToElbowPosition(CraneConstants.kElbowPause, CraneConstants.kExtenderLimit1)) {
-            //         Robot.crane.setWristPosition(CraneConstants.kWristVertical);
-            //         if(upToElbowPosition(CraneConstants.kElbowMid, CraneConstants.kExtenderLimit2)
-            //            && downToElbowPosition(CraneConstants.kElbowMid, CraneConstants.kExtenderLimit2)) {
-            //             Robot.crane.setWristPosition(CraneConstants.kWristVertical);
-            //             Robot.crane.setElbowPosition(CraneConstants.kElbowMid);
-            //             Robot.crane.setExtenderPosition(CraneConstants.kExtenderMid);
-            //         }
-            //     }
-            // }
-            // if(Robot.crane.craneState == 6) { // high reef
-            //     // TODO: VERIFY high reef logic
-            //     if(upToElbowPosition(CraneConstants.kElbowHigh, CraneConstants.kExtenderLimit1)) {
-            //         if(downToElbowPosition(CraneConstants.kElbowPause, CraneConstants.kExtenderLimit2)) {
-            //             if(downToElbowPosition(CraneConstants.kElbowHigh, CraneConstants.kExtenderLimit2 + 10)) {
-            //                 Robot.crane.setWristPosition(CraneConstants.kWristVertical);
-            //                 Robot.crane.setElbowPosition(CraneConstants.kElbowHigh);
-            //                 Robot.crane.setExtenderPosition(CraneConstants.kExtenderHigh);
-            //             }
-            //         }
-            //     }
-            // }
-            // if(Robot.crane.craneState == 0) { // stow
-            //     // TODO: Test stow logic
-            //     // If we want to go to elbow pause, we must retract extender, then we rotate elbow to pause position
-            //     if(downToElbowPosition(CraneConstants.kElbowPause, CraneConstants.kExtenderLimit2)) {
-            //         Robot.crane.setWristPosition(CraneConstants.kWristOrigin);
-            //         if(downToElbowPosition(CraneConstants.kElbowHardDeck, CraneConstants.kExtenderLimit1)) {
-            //             // If elbow is at hard deck, then we slightly retract the extender for stability
-            //             Robot.crane.setWristPosition(CraneConstants.kWristOrigin);
-            //             Robot.crane.setElbowPosition(CraneConstants.kElbowHardDeck);
-            //             Robot.crane.setExtenderPosition(CraneConstants.kExtenderStart);
-            //         }
-            //     }
-            // }
+            if(Robot.crane.craneState == 1) { // station
+                // TODO: VERIFY station logic
+                if(downToElbowPosition(CraneConstants.kElbowPause, CraneConstants.kExtenderLimit2)) {
+                    Robot.crane.setWristPosition(CraneConstants.kWristVertical);
+                    if(downToElbowPosition(CraneConstants.kElbowStation, CraneConstants.kExtenderLimit1)
+                       && upToElbowPosition(CraneConstants.kElbowStation, CraneConstants.kExtenderLimit1)) {
+                        Robot.crane.setWristPosition(CraneConstants.kWristVertical);
+                        Robot.crane.setElbowPosition(CraneConstants.kElbowStation);
+                        Robot.crane.setExtenderPosition(CraneConstants.kExtenderStation);
+                    }
+                }
+            }
+            if(Robot.crane.craneState == 2) { // low pickup
+            // TODO: CHECK LIMITS: bumper, claw dimensions, have MARGIN OF ERROR
+                if(upToElbowPosition(CraneConstants.kElbowPause, CraneConstants.kExtenderLimit1)) {
+                    Robot.crane.setWristPosition(CraneConstants.kWristOrigin);
+                    if(upToElbowPosition(CraneConstants.kElbowCeiling, CraneConstants.kExtenderLimit2)) {
+                        // If elbow is at ceiling, then we extend the extender to pick up the coral
+                        Robot.crane.setWristPosition(CraneConstants.kWristOrigin); // may need to rotate 180 degrees
+                        Robot.crane.setElbowPosition(CraneConstants.kElbowCeiling);
+                        Robot.crane.setExtenderPosition(CraneConstants.kExtenderPickup);
+                    }
+                }
+            }
+            if(Robot.crane.craneState == 3) { // shelf reef
+                // TODO: VERIFY shelf reef logic
+                if(upToElbowPosition(CraneConstants.kElbowPause, CraneConstants.kExtenderLimit1)) {
+                    Robot.crane.setWristPosition(CraneConstants.kWristOrigin);
+                    if(upToElbowPosition(CraneConstants.kElbowShelf, CraneConstants.kExtenderLimit2)
+                       && downToElbowPosition(CraneConstants.kElbowShelf, CraneConstants.kExtenderLimit2)) {
+                        Robot.crane.setWristPosition(CraneConstants.kWristOrigin); // may need to rotate 180 degrees
+                        Robot.crane.setElbowPosition(CraneConstants.kElbowShelf);
+                        Robot.crane.setExtenderPosition(CraneConstants.kExtenderShelf);
+                    }
+                }
+            }
+            if(Robot.crane.craneState == 4) { // low reef
+                // TODO: VERIFY low reef logic
+                if(upToElbowPosition(CraneConstants.kElbowPause, CraneConstants.kExtenderLimit1)) {
+                    Robot.crane.setWristPosition(CraneConstants.kWristVertical);
+                    if(upToElbowPosition(CraneConstants.kElbowLow, CraneConstants.kExtenderLimit2)
+                       && downToElbowPosition(CraneConstants.kElbowLow, CraneConstants.kExtenderLimit2)) {
+                        Robot.crane.setWristPosition(CraneConstants.kWristVertical);
+                        Robot.crane.setElbowPosition(CraneConstants.kElbowLow);
+                        Robot.crane.setExtenderPosition(CraneConstants.kExtenderLow);
+                    }
+                }
+            }
+            if(Robot.crane.craneState == 5) { // mid reef
+                // TODO: VERIFY mid reef logic
+                if(upToElbowPosition(CraneConstants.kElbowPause, CraneConstants.kExtenderLimit1)) {
+                    Robot.crane.setWristPosition(CraneConstants.kWristVertical);
+                    if(upToElbowPosition(CraneConstants.kElbowMid, CraneConstants.kExtenderLimit2)
+                       && downToElbowPosition(CraneConstants.kElbowMid, CraneConstants.kExtenderLimit2)) {
+                        Robot.crane.setWristPosition(CraneConstants.kWristVertical);
+                        Robot.crane.setElbowPosition(CraneConstants.kElbowMid);
+                        Robot.crane.setExtenderPosition(CraneConstants.kExtenderMid);
+                    }
+                }
+            }
+            if(Robot.crane.craneState == 6) { // high reef
+                // TODO: VERIFY high reef logic
+                if(upToElbowPosition(CraneConstants.kElbowHigh, CraneConstants.kExtenderLimit1)) {
+                    if(downToElbowPosition(CraneConstants.kElbowPause, CraneConstants.kExtenderLimit2)) {
+                        if(downToElbowPosition(CraneConstants.kElbowHigh, CraneConstants.kExtenderLimit2 + 10)) {
+                            Robot.crane.setWristPosition(CraneConstants.kWristVertical);
+                            Robot.crane.setElbowPosition(CraneConstants.kElbowHigh);
+                            Robot.crane.setExtenderPosition(CraneConstants.kExtenderHigh);
+                        }
+                    }
+                }
+            }
+            if(Robot.crane.craneState == 0) { // stow
+                // TODO: Test stow logic
+                // If we want to go to elbow pause, we must retract extender, then we rotate elbow to pause position
+                if(downToElbowPosition(CraneConstants.kElbowPause, CraneConstants.kExtenderLimit2)) {
+                    Robot.crane.setWristPosition(CraneConstants.kWristOrigin);
+                    if(downToElbowPosition(CraneConstants.kElbowHardDeck, CraneConstants.kExtenderLimit1)) {
+                        // If elbow is at hard deck, then we slightly retract the extender for stability
+                        Robot.crane.setWristPosition(CraneConstants.kWristOrigin);
+                        Robot.crane.setElbowPosition(CraneConstants.kElbowHardDeck);
+                        Robot.crane.setExtenderPosition(CraneConstants.kExtenderStart);
+                    }
+                }
+            }
         }
 
         SmartDashboard.putNumber("Crane State", Robot.crane.craneState);

--- a/src/main/java/frc/robot/commands/CraneTeleopCommand.java
+++ b/src/main/java/frc/robot/commands/CraneTeleopCommand.java
@@ -143,7 +143,6 @@ public class CraneTeleopCommand extends Command {
     private boolean upToElbowPosition(double elbowPosition, double extenderLimit) {
         // If we want to go to elbow position, we must retract extender, then we rotate elbow
         if(Robot.crane.getElbowPosition() + offset < elbowPosition) {
-            extenderLimit = inchesToDegrees(extenderLimit);
             if(Robot.crane.getExtenderPosition() - offset > extenderLimit
                || Robot.crane.getExtenderPosition() + offset < extenderLimit) {
                 Robot.crane.setExtenderPosition(extenderLimit);
@@ -165,7 +164,6 @@ public class CraneTeleopCommand extends Command {
     private boolean downToElbowPosition(double elbowPosition, double extenderLimit) {
         // If we want to go to elbow position, we must retract extender, then we rotate elbow
         if(Robot.crane.getElbowPosition() - offset > elbowPosition) {
-            extenderLimit = inchesToDegrees(extenderLimit);
             if(Robot.crane.getExtenderPosition() - offset > extenderLimit
                || Robot.crane.getExtenderPosition() + offset < extenderLimit) {
                 Robot.crane.setExtenderPosition(extenderLimit);
@@ -175,10 +173,6 @@ public class CraneTeleopCommand extends Command {
             return false;
         }
         return true;
-    }
-
-    private double inchesToDegrees(double inches) {
-        return inches * 360 / CraneConstants.kPullyCircumferenceInches;
     }
     
     /**

--- a/src/main/java/frc/robot/commands/CraneTeleopCommand.java
+++ b/src/main/java/frc/robot/commands/CraneTeleopCommand.java
@@ -14,8 +14,9 @@ public class CraneTeleopCommand extends Command {
                     prevMidReefState = false,
                     prevHighReefState = false;
     
-    /** Degree of offset so that the crane can progress to the next position. */
-    private double offset = 2.5;
+    /** Degree of angleMargin so that the crane can progress to the next position. */
+    private double angleMargin = 3;
+    private double extensionMargin = 0.5;
 
     public CraneTeleopCommand() {
         addRequirements(Robot.crane);
@@ -38,7 +39,7 @@ public class CraneTeleopCommand extends Command {
         if(PlayerConfigs.fineControlEnable) { // fine control
             Robot.crane.setWristPosition(Robot.crane.wristSetpoint + PlayerConfigs.fineControlWrist * 0.1);
             Robot.crane.setElbowPosition(Robot.crane.elbowSetpoint + PlayerConfigs.fineControlElbow * 0.1);
-            Robot.crane.setExtenderPosition(Robot.crane.extenderSetpoint + PlayerConfigs.fineControlExtender * 0.1);
+            Robot.crane.setExtenderPosition(Robot.crane.extenderSetpoint + PlayerConfigs.fineControlExtender * 0.05);
         } else {
             // if(Robot.crane.craneState == 1) { // station
             //     // TODO: VERIFY station logic
@@ -142,9 +143,9 @@ public class CraneTeleopCommand extends Command {
      */
     private boolean upToElbowPosition(double elbowPosition, double extenderLimit) {
         // If we want to go to elbow position, we must retract extender, then we rotate elbow
-        if(Robot.crane.getElbowPosition() + offset < elbowPosition) {
-            if(Robot.crane.getExtenderPosition() - offset > extenderLimit
-               || Robot.crane.getExtenderPosition() + offset < extenderLimit) {
+        if(Robot.crane.getElbowPosition() + angleMargin < elbowPosition) {
+            if(Robot.crane.getExtenderPosition() - extensionMargin > extenderLimit
+               || Robot.crane.getExtenderPosition() + extensionMargin < extenderLimit) {
                 Robot.crane.setExtenderPosition(extenderLimit);
             } else {
                 Robot.crane.setElbowPosition(elbowPosition);
@@ -163,9 +164,9 @@ public class CraneTeleopCommand extends Command {
      */
     private boolean downToElbowPosition(double elbowPosition, double extenderLimit) {
         // If we want to go to elbow position, we must retract extender, then we rotate elbow
-        if(Robot.crane.getElbowPosition() - offset > elbowPosition) {
-            if(Robot.crane.getExtenderPosition() - offset > extenderLimit
-               || Robot.crane.getExtenderPosition() + offset < extenderLimit) {
+        if(Robot.crane.getElbowPosition() - angleMargin > elbowPosition) {
+            if(Robot.crane.getExtenderPosition() - extensionMargin > extenderLimit
+               || Robot.crane.getExtenderPosition() + extensionMargin < extenderLimit) {
                 Robot.crane.setExtenderPosition(extenderLimit);
             } else {
                 Robot.crane.setElbowPosition(elbowPosition);

--- a/src/main/java/frc/robot/subsystems/Crane.java
+++ b/src/main/java/frc/robot/subsystems/Crane.java
@@ -76,6 +76,11 @@ public class Crane extends SubsystemBase {
         gripperConfig
             .inverted(true)
             .idleMode(IdleMode.kBrake);
+        gripperConfig.softLimit
+            .forwardSoftLimitEnabled(true)
+            .reverseSoftLimitEnabled(true)
+            .forwardSoftLimit(CraneConstants.kGripperCeiling)
+            .reverseSoftLimit(CraneConstants.kGripperHardDeck);
         gripperConfig.encoder
         // TODO: Ratio needs to be changed
             .positionConversionFactor(CraneConstants.kGripperEncoderDistancePerPulse)
@@ -88,6 +93,11 @@ public class Crane extends SubsystemBase {
     
         wristConfig
             .idleMode(IdleMode.kBrake);
+        wristConfig.softLimit
+            .forwardSoftLimitEnabled(true)
+            .reverseSoftLimitEnabled(true)
+            .forwardSoftLimit(CraneConstants.kWristCeiling)
+            .reverseSoftLimit(CraneConstants.kElbowHardDeck);
         wristConfig.encoder
         // TODO: Ratio needs to be changed
             .positionConversionFactor(CraneConstants.kWristEncoderDistancePerPulse)
@@ -101,6 +111,11 @@ public class Crane extends SubsystemBase {
         elbowConfig
             .inverted(true)
             .idleMode(IdleMode.kBrake);
+        elbowConfig.softLimit
+            .forwardSoftLimitEnabled(true)
+            .reverseSoftLimitEnabled(true)
+            .forwardSoftLimit(CraneConstants.kElbowCeiling + 2)
+            .reverseSoftLimit(CraneConstants.kElbowHardDeck - 2);
         elbowConfig.encoder
             .positionConversionFactor(CraneConstants.kElbowEncoderDistancePerPulse)
             .velocityConversionFactor(CraneConstants.kElbowEncoderDistancePerPulse);
@@ -112,7 +127,13 @@ public class Crane extends SubsystemBase {
         elbowMotor.configure(elbowConfig, ResetMode.kResetSafeParameters, PersistMode.kPersistParameters);
 
         extenderConfig
+            .inverted(true)
             .idleMode(IdleMode.kBrake);
+        extenderConfig.softLimit
+            .forwardSoftLimitEnabled(true)
+            .reverseSoftLimitEnabled(true)
+            .forwardSoftLimit(inchesToDegrees(CraneConstants.kExtenderCeiling))
+            .reverseSoftLimit(inchesToDegrees(CraneConstants.kExtenderHardDeck));
         extenderConfig.encoder
             .positionConversionFactor(CraneConstants.kExtenderEncoderDistancePerPulse)
             .velocityConversionFactor(CraneConstants.kExtenderEncoderDistancePerPulse);
@@ -187,6 +208,10 @@ public class Crane extends SubsystemBase {
     private double inchesToDegrees(double inches) {
         return inches * 360 / CraneConstants.kPullyCircumferenceInches;
     }
+
+    private double degreesToInches(double degrees) {
+        return degrees * CraneConstants.kPullyCircumferenceInches / 360;
+    }
     
     /**
      * Returns the ceiling if the setpoint is above it, or the hard deck if the setpoint is below it.
@@ -210,7 +235,7 @@ public class Crane extends SubsystemBase {
 
     /** Returns the extension of the extender in inches, 0 = retracted, ceiling = extended, CCW+. */
     public double getExtenderPosition() {
-        return inchesToDegrees(CraneConstants.kExtenderCeiling - extenderMotor.getEncoder().getPosition());
+        return CraneConstants.kExtenderStart - degreesToInches(extenderMotor.getEncoder().getPosition());
     }
 
     /** Returns the angle of the gripper in degrees, CW+. */

--- a/src/main/java/frc/robot/subsystems/Crane.java
+++ b/src/main/java/frc/robot/subsystems/Crane.java
@@ -203,20 +203,22 @@ public class Crane extends SubsystemBase {
         return setPoint;
     }
 
-    /** Relative to the chassis up from starting is positive. */
+    /** Returns the current angle of the elbow in degrees, CW+. */
     public double getElbowPosition() {
         return elbowMotor.getEncoder().getPosition();
     }
 
-    /** Returns the extension of the extender in inches. */
+    /** Returns the extension of the extender in inches, 0 = retracted, ceiling = extended, CCW+. */
     public double getExtenderPosition() {
         return inchesToDegrees(CraneConstants.kExtenderCeiling - extenderMotor.getEncoder().getPosition());
     }
 
-    public double getGripperMotor() {
+    /** Returns the angle of the gripper in degrees, CW+. */
+    public double getGripperPosition() {
         return gripperMotor.getEncoder().getPosition();
     }
 
+    /** Returns the angle of the wrist in degrees, CCW+. */
     public double getWristPosition() {
         return wristMotor.getEncoder().getPosition();
     }

--- a/src/main/java/frc/robot/subsystems/Crane.java
+++ b/src/main/java/frc/robot/subsystems/Crane.java
@@ -125,9 +125,9 @@ public class Crane extends SubsystemBase {
     }
 
     /**
-     * Sets the position of the gripper relative to its starting position, CW+.
+     * Sets the angle of the gripper, shaft CW+.
      * 
-     * @param setPoint The desired position of the gripper Motor
+     * @param setPoint The desired angle of the gripper in degrees
      */
     public void setGripperPosition(double setPoint) {
         gripperSetpoint = filterSetPoint(setPoint,
@@ -138,9 +138,9 @@ public class Crane extends SubsystemBase {
     }
 
     /**
-     * Sets the position of the wrist relative to its starting position
+     * Sets the angle of the wrist, shaft CCW+.
      * 
-     * @param setPoint The desired position of the wrist motor
+     * @param setPoint The desired angle of the wrist in degrees
      */
     public void setWristPosition(double setPoint) {
         wristSetpoint = filterSetPoint(setPoint, 
@@ -151,9 +151,9 @@ public class Crane extends SubsystemBase {
     }
 
     /**
-     * Sets the position of the elbow relative to its starting position, CW+.
+     * Sets the angle of the elbow, shaft CW+.
      * 
-     * @param setPoint The desired position of the elbow motor
+     * @param setPoint The desired angle of the elbow in degrees
      */
     public void setElbowPosition(double setPoint) {
         elbowSetpoint = filterSetPoint(setPoint, 
@@ -165,11 +165,11 @@ public class Crane extends SubsystemBase {
     }
 
     /**
-     * Sets the position of the extender relative to its starting position.
+     * Sets the extension of the extender, setpoint and actual position are flipped.
      * Full extension is setpoint = ceiling, motor = 0.
      * Full retraction is setpoint = 0, motor = ceiling.
      * 
-     * @param setPoint The desired position of the extender motor
+     * @param setPoint The desired extension of the extender in inches
      */
     public void setExtenderPosition(double setPoint) {
         // Full extension is setpoint = ceiling, motor = 0
@@ -208,9 +208,9 @@ public class Crane extends SubsystemBase {
         return elbowMotor.getEncoder().getPosition();
     }
 
-    /** Relative to the elbow joint, 0 is fully retracted, ceiling is fully extended. */
+    /** Returns the extension of the extender in inches. */
     public double getExtenderPosition() {
-        return CraneConstants.kExtenderCeiling - extenderMotor.getEncoder().getPosition();
+        return inchesToDegrees(CraneConstants.kExtenderCeiling - extenderMotor.getEncoder().getPosition());
     }
 
     public double getGripperMotor() {

--- a/src/main/java/frc/robot/subsystems/Crane.java
+++ b/src/main/java/frc/robot/subsystems/Crane.java
@@ -122,7 +122,7 @@ public class Crane extends SubsystemBase {
         elbowConfig.closedLoop
             .feedbackSensor(FeedbackSensor.kPrimaryEncoder)
             // TODO: PID values changed temporarily for testing, 1/25/2025 was: 0.01, 0.01, 0.5 
-            .pid(0.01, 0.0, 0.5);
+            .pid(0.005, 0.0, 0.0);
             
         elbowMotor.configure(elbowConfig, ResetMode.kResetSafeParameters, PersistMode.kPersistParameters);
 
@@ -140,7 +140,7 @@ public class Crane extends SubsystemBase {
         extenderConfig.closedLoop
             .feedbackSensor(FeedbackSensor.kPrimaryEncoder)
             // TODO: PID values changed temporarily for testing, 1/25/2025 was: 0.01, 0.01, 0.1
-            .pid(0.01, 0.0, 0.1);
+            .pid(0.005, 0.0, 0.1);
             
         extenderMotor.configure(extenderConfig, ResetMode.kResetSafeParameters, PersistMode.kPersistParameters);
     }

--- a/src/main/java/frc/robot/subsystems/Crane.java
+++ b/src/main/java/frc/robot/subsystems/Crane.java
@@ -67,7 +67,11 @@ public class Crane extends SubsystemBase {
         extenderConfig = new SparkMaxConfig();
         extenderPID = extenderMotor.getClosedLoopController();
 
-        extenderSetpoint = CraneConstants.kExtenderCeiling;
+        // Set up setpoints for each motor
+        gripperSetpoint = CraneConstants.kGripperHardDeck;
+        wristSetpoint = CraneConstants.kWristOrigin;
+        elbowSetpoint = CraneConstants.kElbowHardDeck;
+        extenderSetpoint = CraneConstants.kExtenderStart;
 
         gripperConfig
             .idleMode(IdleMode.kBrake);

--- a/src/main/java/frc/robot/subsystems/Crane.java
+++ b/src/main/java/frc/robot/subsystems/Crane.java
@@ -74,9 +74,9 @@ public class Crane extends SubsystemBase {
         extenderSetpoint = CraneConstants.kExtenderStart;
 
         gripperConfig
+            .inverted(true)
             .idleMode(IdleMode.kBrake);
         gripperConfig.encoder
-            // .inverted(true)
         // TODO: Ratio needs to be changed
             .positionConversionFactor(CraneConstants.kGripperEncoderDistancePerPulse)
             .velocityConversionFactor(CraneConstants.kGripperEncoderDistancePerPulse);
@@ -99,9 +99,9 @@ public class Crane extends SubsystemBase {
         wristMotor.configure(wristConfig, ResetMode.kResetSafeParameters, PersistMode.kPersistParameters);
 
         elbowConfig
+            .inverted(true)
             .idleMode(IdleMode.kBrake);
         elbowConfig.encoder
-            // .inverted(true)
             .positionConversionFactor(CraneConstants.kElbowEncoderDistancePerPulse)
             .velocityConversionFactor(CraneConstants.kElbowEncoderDistancePerPulse);
         elbowConfig.closedLoop
@@ -133,7 +133,7 @@ public class Crane extends SubsystemBase {
         gripperSetpoint = filterSetPoint(setPoint,
                                          CraneConstants.kGripperHardDeck,
                                          CraneConstants.kGripperCeiling);
-        gripperPID.setReference(-gripperSetpoint, ControlType.kPosition);
+        gripperPID.setReference(gripperSetpoint, ControlType.kPosition);
         SmartDashboard.putNumber("Gripper Setpoint", setPoint);
     }
 
@@ -160,7 +160,7 @@ public class Crane extends SubsystemBase {
                                        CraneConstants.kElbowHardDeck, 
                                        CraneConstants.kElbowCeiling);
         System.out.println(elbowSetpoint);
-        elbowPID.setReference(-elbowSetpoint, ControlType.kPosition);
+        elbowPID.setReference(elbowSetpoint, ControlType.kPosition);
         SmartDashboard.putNumber("Elbow Setpoint", elbowSetpoint);
     }
 
@@ -205,7 +205,7 @@ public class Crane extends SubsystemBase {
 
     /** Relative to the chassis up from starting is positive. */
     public double getElbowPosition() {
-        return -elbowMotor.getEncoder().getPosition();
+        return elbowMotor.getEncoder().getPosition();
     }
 
     /** Relative to the elbow joint, 0 is fully retracted, ceiling is fully extended. */
@@ -214,7 +214,7 @@ public class Crane extends SubsystemBase {
     }
 
     public double getGripperMotor() {
-        return -gripperMotor.getEncoder().getPosition();
+        return gripperMotor.getEncoder().getPosition();
     }
 
     public double getWristPosition() {

--- a/src/main/java/frc/robot/subsystems/Crane.java
+++ b/src/main/java/frc/robot/subsystems/Crane.java
@@ -68,10 +68,10 @@ public class Crane extends SubsystemBase {
         extenderPID = extenderMotor.getClosedLoopController();
 
         // Set up setpoints for each motor
-        gripperSetpoint = CraneConstants.kGripperHardDeck;
-        wristSetpoint = CraneConstants.kWristOrigin;
-        elbowSetpoint = CraneConstants.kElbowHardDeck;
-        extenderSetpoint = CraneConstants.kExtenderStart;
+        setGripperPosition(CraneConstants.kGripperHardDeck);
+        setWristPosition(CraneConstants.kWristOrigin);
+        setElbowPosition(CraneConstants.kElbowHardDeck);
+        setExtenderPosition(CraneConstants.kExtenderStart);
 
         gripperConfig
             .inverted(true)
@@ -177,7 +177,7 @@ public class Crane extends SubsystemBase {
         extenderSetpoint = filterSetPoint(setPoint, 
                                           CraneConstants.kExtenderHardDeck, 
                                           CraneConstants.kExtenderCeiling);
-        setPoint = CraneConstants.kExtenderCeiling - extenderSetpoint;
+        setPoint = CraneConstants.kExtenderStart - extenderSetpoint;
         System.out.println("Extender: " + extenderSetpoint);
         setPoint = inchesToDegrees(setPoint);
         extenderPID.setReference(setPoint, ControlType.kPosition);


### PR DESCRIPTION
During the simulation, I realized I had overlooked a few things regarding unit conversion in the extender. This should fix that. In addition to this issue, I also fixed a few other oversights, like not having well-defined starting positions for crane motors. We will now set motor inversion with the config (the correct way to invert it since motor controllers may not all be configured correctly when swapping out). I clarified the documentation to prevent unit-related errors.